### PR TITLE
Add unittests and update documentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "jsonschema"]
+	path = jsonschema-draft6
+	url = git@github.com:devicetree-org/jsonschema.git
+	branch = draft6
+	ignore = dirty

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	test/test-dt-validate.py
+
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -13,3 +13,30 @@ jsonschema and pyyaml libraries.
 
 Please note: this is prototype code and is in no way officially supported or
 fit for use.
+
+## Dependencies
+This code depends on Python 3 with the yaml and jsonschema libraries
+
+On Debian, the dependencies can be installed with:
+
+```
+apt-get install python3 python-yaml
+```
+
+### jsonschema Draft6
+This code depends on the 'draft6' branch of the
+[Python jsonschema](https://github.com/Julian/jsonschema/tree/draft6)
+library.
+The draft6 branch is incomplete and unreleased, so you will need to get
+a local copy instead of using a packaged version.
+For convenience a [fork of the draft6 branch](https://github.com/devicetree-org/jsonschema/tree/draft6)
+is maintained in the devicetree.org GitHub page,
+and this repo includes it as a git submodule.
+
+To fetch the submodule use the following commands:
+
+```
+git submodule init
+git submodule update
+cd jsonschema-draft6 && python3 setup.py && cd ..
+```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,69 @@ files are written in YAML (a superset of JSON), and operate on the YAML
 encoding of Devicetree data. Devicetree data must be transcoded from DTS to
 YAML before being used by this tool
 
+## Data Model
+
+To understand how validation works, it is important to understand how schema data is organized and used.
+If you're reading this, I assume you're already familiar with Devicetree and the .dts file format.
+
+In this repository you will find three kinds of files; *YAML Devicetrees*, *Schemas* and *Meta-Schemas*.
+
+### *YAML Devicetrees*
+
+Found under `./test`
+
+*YAML Devicetrees* files are regular .dts files transcoded into a YAML
+representation.
+There is no special information in these files.
+They are used as test cases against the validation tooling.
+
+### *Devicetree Schemas*
+
+Found under `./schemas`
+
+*Devicetree Schemas* describe the format of devicetree data.
+The raw Devicetree file format is very open ended and doesn't restrict how
+data is encoded.
+Hence, it is easy to make mistakes when writing a Devicetree.
+Schema files impose constraints on what data can be put into a devicetree.
+As the foundation, a single core schema describes all the common property types
+that every devicetree node must match.
+e.g. In every node the 'compatible' property must be an array of strings.
+However, most devicetree data is heterogeneous as each device binding requires
+a different set of data, therefore multiple schema files are used to capture the
+data format of an entire devicetree.
+
+When validating, the tool will load all the schema files it can find and then
+iterate over all the nodes of the devicetree.
+For each node, the tool will determine which schema(s) are applicable and make sure
+the node data matches the schema constraints.
+Nodes failing a schema test will emit an error.
+Nodes that don't match any schema will emit a warning.
+
+As a developer, you would write a devicetree schema file for each new
+device binding that you create and add it to the `./schemas` directory.
+
+Schema files also have the dual purpose of documenting a binding.
+When you define a new binding, you only have to create one file that contains
+both the machine-verifiable data format and the documentation.
+Documentation generation tools are being written to extract documentation
+from a schema file and emit a format that can be included in the devicetree
+specification documents.
+
+Devicetree Schema files are normal YAML files using the jsonschema vocabulary.
+
+### *Devicetree Meta-Schemas*
+
+Found in `./meta-schemas`
+
+*Devicetree Meta-Schemas* describe the data format of Devicetree Schema files.
+The Meta-schemas make sure all the binding schemas are in the correct format
+and the tool will emit an error is the format is incorrect.
+
+As a developer you normally will not need to write metaschema files.
+
+Devicetree Meta-Schema files are normal YAML files using the jsonschema vocabulary.
+
 ## Usage
 The tool in this repo can be run by simply executing the dt-validate.py script
 at the top level. It requires Python 3 to be installed, as well as the

--- a/dt-validate.py
+++ b/dt-validate.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
 import sys
+import os
+basedir = os.path.dirname(__file__)
 import yaml
+sys.path.insert(0, os.path.join(basedir, "jsonschema-draft6"))
 import jsonschema
 import argparse
 import glob

--- a/dt-validate.py
+++ b/dt-validate.py
@@ -67,8 +67,7 @@ class schema_group():
 
         # Check that the selection schema is valid. The selection
         # schema determines when a binding should get applied
-        resolver = jsonschema.RefResolver.from_schema(schema)
-        validator = jsonschema.Draft6Validator(schema, resolver=resolver)
+        validator = jsonschema.Draft6Validator(schema)
         if "select" in schema.keys():
             try:
                 validator.check_schema(schema["select"])
@@ -89,11 +88,10 @@ class schema_group():
         node_matched = False
         for schema in self.schemas:
             if "select" in schema.keys():
-                resolver = jsonschema.RefResolver.from_schema(schema)
-                v = jsonschema.Draft6Validator(schema["select"], resolver=resolver)
+                v = jsonschema.Draft6Validator(schema["select"])
                 if v.is_valid(node):
                     node_matched = True
-                    v2 = jsonschema.Draft6Validator(schema, resolver=resolver)
+                    v2 = jsonschema.Draft6Validator(schema)
                     errors = sorted(v2.iter_errors(node), key=lambda e: e.path)
                     if (errors):
                         for error in errors:

--- a/dt-validate.py
+++ b/dt-validate.py
@@ -59,7 +59,7 @@ class schema_group():
 
         # Check that the validation schema is valid
         try:
-            jsonschema.Draft4Validator.check_schema(schema)
+            jsonschema.Draft6Validator.check_schema(schema)
         except jsonschema.SchemaError as exc:
             print(filename + ": ignoring, error in schema '%s'" % exc.path[-1])
             #print(exc.message)

--- a/dt-validate.py
+++ b/dt-validate.py
@@ -71,7 +71,7 @@ class schema_group():
         validator = jsonschema.Draft6Validator(schema, resolver=resolver)
         if "select" in schema.keys():
             try:
-                validator.check_schema(schema)
+                validator.check_schema(schema["select"])
             except jsonschema.SchemaError as exc:
                 print("Error(s) validating schema", filename, exc)
                 return

--- a/dtschema.py
+++ b/dtschema.py
@@ -9,13 +9,14 @@ import pkgutil
 
 schema_base_url = "http://devicetree.org/"
 
+def load_schema(schema):
+    return yaml.load(pkgutil.get_data('dtschema', schema).decode('utf-8'))
+
 def http_handler(uri):
     '''Custom handler for http://devicetre.org YAML references'''
     if schema_base_url in uri:
-        yamlfile = pkgutil.get_data("dtschema", uri.replace(schema_base_url, ""))
-    else:
-        yamlfile = jsonschema.compat.urlopen(uri).read()
-    return yaml.load(yamlfile.decode("utf-8"))
+        return load_schema(uri.replace(schema_base_url, ''))
+    return yaml.load(jsonschema.compat.urlopen(uri).read().decode('utf-8'))
 
 handlers = {"http": http_handler}
 

--- a/dtschema.py
+++ b/dtschema.py
@@ -5,33 +5,26 @@ import yaml
 sys.path.insert(0, os.path.join(os.path.dirname(__file__),
                                 "jsonschema-draft6"))
 import jsonschema
+import pkgutil
 
-schema_base_url = "http://devicetree.org"
+schema_base_url = "http://devicetree.org/"
 
 def http_handler(uri):
     '''Custom handler for http://devicetre.org YAML references'''
     if schema_base_url in uri:
-        f = open(uri.replace(schema_base_url, os.getcwd()))
-        yamlfile = f.read()
-        f.close()
+        yamlfile = pkgutil.get_data("dtschema", uri.replace(schema_base_url, ""))
     else:
-        yamlfile = jsonschema.compat.urlopen(uri).read().decode("utf-8")
-    return yaml.load(yamlfile)
+        yamlfile = jsonschema.compat.urlopen(uri).read()
+    return yaml.load(yamlfile.decode("utf-8"))
 
 handlers = {"http": http_handler}
 
-def DTValidator():
-    f = open("schemas/dt-core.yaml")
-    schema = yaml.load(f.read())
-    f.close()
-
+def DTValidator(schema):
     resolver = jsonschema.RefResolver.from_schema(schema, handlers=handlers)
     return jsonschema.Draft6Validator(schema, resolver=resolver)
 
 def DTMetaValidator():
-    f = open("meta-schemas/core.yaml")
-    schema = yaml.load(f.read())
-    f.close()
+    schema = yaml.load(pkgutil.get_data("dtschema", "meta-schemas/core.yaml").decode("utf-8"))
 
     resolver = jsonschema.RefResolver.from_schema(schema, handlers=handlers)
     return jsonschema.Draft6Validator(schema, resolver=resolver)

--- a/dtschema.py
+++ b/dtschema.py
@@ -1,0 +1,37 @@
+# Python library for Devicetree schema validation
+import sys
+import os
+import yaml
+sys.path.insert(0, os.path.join(os.path.dirname(__file__),
+                                "jsonschema-draft6"))
+import jsonschema
+
+schema_base_url = "http://devicetree.org"
+
+def http_handler(uri):
+    '''Custom handler for http://devicetre.org YAML references'''
+    if schema_base_url in uri:
+        f = open(uri.replace(schema_base_url, os.getcwd()))
+        yamlfile = f.read()
+        f.close()
+    else:
+        yamlfile = jsonschema.compat.urlopen(uri).read().decode("utf-8")
+    return yaml.load(yamlfile)
+
+handlers = {"http": http_handler}
+
+def DTValidator():
+    f = open("schemas/dt-core.yaml")
+    schema = yaml.load(f.read())
+    f.close()
+
+    resolver = jsonschema.RefResolver.from_schema(schema, handlers=handlers)
+    return jsonschema.Draft6Validator(schema, resolver=resolver)
+
+def DTMetaValidator():
+    f = open("meta-schemas/core.yaml")
+    schema = yaml.load(f.read())
+    f.close()
+
+    resolver = jsonschema.RefResolver.from_schema(schema, handlers=handlers)
+    return jsonschema.Draft6Validator(schema, resolver=resolver)

--- a/meta-schemas/core.yaml
+++ b/meta-schemas/core.yaml
@@ -34,9 +34,10 @@ properties:
     pattern: 'http://devicetree.org/schemas/.*\.yaml#'
   $schema:
     const: "http://json-schema.org/draft-06/schema#"
-
-  title: {}
-  description: {}
+  title: true
+  description: true
+  examples: true
+  required: true
 
   version:
     type: integer
@@ -54,10 +55,6 @@ properties:
       - $ref: "clocks.yaml#"
       - $ref: "gpios.yaml#"
       - $ref: "interrupts.yaml#"
-
-  required: {}
-
-  examples: {}
 
 required:
   - $id

--- a/meta-schemas/core.yaml
+++ b/meta-schemas/core.yaml
@@ -31,13 +31,15 @@ definitions:
 properties:
   # listing all properties here so additionalProperties works
   $id:
-    pattern: 'http://devicetree.org/.*/schemas/.*\.yaml#'
+    pattern: 'http://devicetree.org/(test/)?schemas/.*\.yaml#'
   $schema:
     const: "http://devicetree.org/meta-schemas/core.yaml#"
   title: true
   description: true
   examples: true
   required: true
+  allOf: true
+  definitions: true
 
   version:
     type: integer
@@ -56,6 +58,8 @@ properties:
       - $ref: "gpios.yaml#"
       - $ref: "interrupts.yaml#"
 
+  select: { $ref: "http://json-schema.org/draft-06/schema#" }
+
 required:
   - $id
   - $schema
@@ -63,8 +67,5 @@ required:
   - title
   - maintainers
   - description
-  - examples
-  - properties
-  - required
 
 additionalProperties: false

--- a/meta-schemas/core.yaml
+++ b/meta-schemas/core.yaml
@@ -31,9 +31,9 @@ definitions:
 properties:
   # listing all properties here so additionalProperties works
   $id:
-    pattern: 'http://devicetree.org/schemas/.*\.yaml#'
+    pattern: 'http://devicetree.org/.*/schemas/.*\.yaml#'
   $schema:
-    const: "http://json-schema.org/draft-06/schema#"
+    const: "http://devicetree.org/meta-schemas/core.yaml#"
   title: true
   description: true
   examples: true

--- a/meta-schemas/core.yaml
+++ b/meta-schemas/core.yaml
@@ -2,7 +2,7 @@
 ---
 $id: "http://devicetree.org/meta-schemas/core.yaml#"
 $schema: "http://json-schema.org/draft-06/schema#"
-description: "Schema for devicetree binding documentation"
+description: "Metaschema for devicetree binding documentation"
 
 allOf: [ { $ref: "http://json-schema.org/draft-06/schema#" } ]
 

--- a/meta-schemas/core.yaml
+++ b/meta-schemas/core.yaml
@@ -4,7 +4,7 @@ $id: "http://devicetree.org/meta-schemas/core.yaml#"
 $schema: "http://json-schema.org/draft-06/schema#"
 description: "Schema for devicetree binding documentation"
 
-type: object
+allOf: [ { $ref: "http://json-schema.org/draft-06/schema#" } ]
 
 definitions:
   core-properties:

--- a/schemas/dt-core.yaml
+++ b/schemas/dt-core.yaml
@@ -6,7 +6,7 @@
 #   Should it be disallowed, and always enforce the correct array wrapping?
 
 $id: "http://devicetree.org/alpha-01/schema-core#"
-$schema: "http://json-schema.org/draft-04/schema#"
+$schema: "http://json-schema.org/draft-06/schema#"
 description: "Schema for core devicetree bindings"
 
 # always select the core schema

--- a/schemas/dt-core.yaml
+++ b/schemas/dt-core.yaml
@@ -7,7 +7,12 @@
 
 $id: "http://devicetree.org/schemas/dt-core.yaml#"
 $schema: "http://devicetree.org/meta-schemas/core.yaml#"
+title: Core devicetree node schema which applies to all nodes
 description: "Schema for core devicetree bindings"
+maintainers:
+  - Grant Likely <grant.likely@arm.com>
+  - Rob Herring <robh@kernel.org>
+version: 1
 
 # always select the core schema
 select: true

--- a/schemas/dt-core.yaml
+++ b/schemas/dt-core.yaml
@@ -5,8 +5,8 @@
 #   This is nicer for humans, but makes things more complicated to parse.
 #   Should it be disallowed, and always enforce the correct array wrapping?
 
-$id: "http://devicetree.org/alpha-01/schema-core#"
-$schema: "http://json-schema.org/draft-06/schema#"
+$id: "http://devicetree.org/schemas/dt-core.yaml#"
+$schema: "http://devicetree.org/meta-schemas/core.yaml#"
 description: "Schema for core devicetree bindings"
 
 # always select the core schema

--- a/schemas/root-node.yaml
+++ b/schemas/root-node.yaml
@@ -1,12 +1,13 @@
 %YAML 1.2
 ---
-type: object
 $id: http://devicetree.org/schemas/root-node.yaml#
-$schema: http://json-schema.org/draft-06/schema#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
 
 version: 1
 
 title: Common root node
+description: |
+  Common properties always required in the root node of the tree
 
 maintainers:
   - Device Tree <dt@kernel.org>
@@ -30,4 +31,17 @@ required:
   - "#address-cells"
   - "#size-cells"
   - memory
-  - "$path"
+  - $path
+
+examples:
+  simple-board: |
+    / {
+        compatible = "acme,boogieboard";
+        model = "Acme Ltd. Boogieboard developer system";
+        #address-cells = <1>;
+        #size-cells = <1>;
+        memory@0 {
+            reg = <0 0x10000000>;
+        };
+        $path = "/";
+    }

--- a/schemas/soc/arm/juno.yaml
+++ b/schemas/soc/arm/juno.yaml
@@ -1,13 +1,16 @@
 %YAML 1.1
 ---
-$id: "http://devicetree.org/schemas/soc/example.yaml#"
-$schema: "http://json-schema.org/draft-06/schema#"
+$id: http://devicetree.org/schemas/soc/example.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
 version: 1
 
 title: ARM Juno boards
 
 description: >
   A board binding example. Matches on a top-level compatible string and model.
+
+maintainers:
+  - nobody@nowhere.com
 
 required:
 - psci
@@ -25,7 +28,8 @@ properties:
       - "ARM Juno development board (r1)"
       - "ARM Juno development board (r2)"
 
-example: |
+examples:
+  example: |
     /dts-v1/;
     / {
         model = "ARM Juno development board (r0)";

--- a/schemas/soc/board-example.yaml
+++ b/schemas/soc/board-example.yaml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
-$id: "http://devicetree.org/schemas/soc/arm/board-example.yaml#"
-$schema: "http://json-schema.org/draft-06/schema#"
+$id: http://devicetree.org/schemas/soc/arm/board-example.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
 version: 1
 
 title: A board example using compatible and model properties
@@ -13,32 +13,23 @@ description: An SoC binding example. Matches on a top-level compatible string an
   model.
 
 properties:
-  $path:
-    type: string
-    const: "/"
   compatible:
-    description: Compatible strings for the board example.
     oneOf:
       - items:
           - enum:
               - "example,board1-with-soc1"
               - "example,board2-with-soc1"
           - const: "example,soc1"
+        minItems: 1
+        maxItems: 2
         additionalItems: false
       - items:
           - enum:
               - "example,board-with-soc2"
           - const: "example,soc2"
+        minItems: 1
+        maxItems: 2
         additionalItems: false
-    minItems: 2
-    maxItems: 2
-
-  model:
-    type: string
-
-required:
-  - $path
-  - compatible
 
 examples:
   - example: |

--- a/test/schemas/bad-example.yaml
+++ b/test/schemas/bad-example.yaml
@@ -1,13 +1,12 @@
 %YAML 1.2
 ---
-$id: "http://devicetree.org/schemas/test/bad-example.yaml"
+$id: "http://devicetree.org/test/schemas/bad-example.yaml"
 $schema: "http://jsn-schema.org/draft-06/schema#"
 version: 2
 
 title: 0
 
-maintainers:
-  - Bob
+maintainers: Bob
 
 description:
   - The description should not be a sequence.
@@ -38,7 +37,7 @@ properties:
 
   reg:
     minItems: 2
-    maxItems: 1
+    maxItems: 0
 
   interrupts:
     description: 0
@@ -59,9 +58,6 @@ properties:
     const: 'foo'
     description: 0
 
-  clock-output-names:
-    const: "clk1"
-
   gpio-controller:
     const: 'foo'
 
@@ -71,11 +67,6 @@ properties:
   some-gpios:
     description: 0
 
-  model:
-    description: A description of model
-    enum:
-      - "ARM Juno development board (r1)"
-      - "ARM Juno development board (r2)"
   another-property:
     description: 0
 

--- a/test/schemas/good-example.yaml
+++ b/test/schemas/good-example.yaml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
-$id: "http://devicetree.org/schemas/test/good-example.yaml#"
-$schema: "http://json-schema.org/draft-06/schema#"
+$id: "http://devicetree.org/test/schemas/good-example.yaml#"
+$schema: "http://devicetree.org/meta-schemas/core.yaml#"
 version: 1
 
 title: A one line title for a good binding

--- a/test/test-dt-validate.py
+++ b/test/test-dt-validate.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import unittest
+import os
+import sys
+basedir = os.path.dirname(__file__)
+import yaml
+sys.path.insert(0, os.path.join(basedir, "../jsonschema-draft6"))
+import jsonschema
+sys.path.insert(0, os.path.join(basedir, ".."))
+import dtschema
+
+#validator = dtschema.DTValidator()
+
+class TestDTMetaSchema(unittest.TestCase):
+    def setUp(self):
+        f = open("test/schemas/good-example.yaml")
+        self.schema = yaml.load(f.read())
+        f.close()
+
+        f = open("test/schemas/bad-example.yaml")
+        self.bad_schema = yaml.load(f.read())
+        f.close()
+
+        self.validator = dtschema.DTMetaValidator()
+
+    def test_required_properties(self):
+        self.validator.validate(self.schema)
+
+    def test_required_property_missing(self):
+        for key in self.schema.keys():
+            if key in ['$id']:
+                continue
+            with self.subTest(k=key):
+                schema_tmp = self.schema.copy()
+                del schema_tmp[key]
+                self.assertRaises(jsonschema.ValidationError, self.validator.validate, schema_tmp)
+
+    def test_bad_schema(self):
+        '''bad-example.yaml is all bad. There is no condition where it should pass validation'''
+        self.assertRaises(jsonschema.ValidationError, self.validator.validate, self.bad_schema)
+
+    def test_bad_properties(self):
+        for key in self.bad_schema.keys():
+            if key == 'properties':
+                continue
+
+            with self.subTest(k=key):
+                schema_tmp = self.schema.copy()
+                schema_tmp[key] = self.bad_schema[key]
+                self.assertRaises(jsonschema.ValidationError, self.validator.validate, schema_tmp)
+
+        bad_props = self.bad_schema['properties']
+        schema_tmp = self.schema.copy()
+        for key in bad_props.keys():
+            with self.subTest(k="properties/"+key):
+                schema_tmp['properties'] = self.schema['properties'].copy()
+                schema_tmp['properties'][key] = bad_props[key]
+                self.assertRaises(jsonschema.ValidationError, self.validator.validate, schema_tmp)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test-dt-validate.py
+++ b/test/test-dt-validate.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
+#
+# Testcases for the Devicetree schema files and validation library
+#
+# Copyright 2018 Arm Ltd.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Testcases are executed by running 'make test' from the top level directory of this repo.
+
 import unittest
 import os
+import glob
 import sys
 basedir = os.path.dirname(__file__)
 import yaml
@@ -8,14 +18,13 @@ sys.path.insert(0, os.path.join(basedir, "../jsonschema-draft6"))
 import jsonschema
 sys.path.insert(0, os.path.join(basedir, ".."))
 import dtschema
-import pkgutil
 
 #validator = dtschema.DTValidator()
 
 class TestDTMetaSchema(unittest.TestCase):
     def setUp(self):
-        self.schema = yaml.load(pkgutil.get_data("dtschema", "test/schemas/good-example.yaml").decode("utf-8"))
-        self.bad_schema = yaml.load(pkgutil.get_data("dtschema", "test/schemas/bad-example.yaml").decode("utf-8"))
+        self.schema = dtschema.load_schema('test/schemas/good-example.yaml')
+        self.bad_schema = dtschema.load_schema('test/schemas/bad-example.yaml')
         self.validator = dtschema.DTMetaValidator()
 
     def test_required_properties(self):
@@ -23,7 +32,7 @@ class TestDTMetaSchema(unittest.TestCase):
 
     def test_required_property_missing(self):
         for key in self.schema.keys():
-            if key in ['$id']:
+            if key in ['$id', 'properties', 'required', 'examples']:
                 continue
             with self.subTest(k=key):
                 schema_tmp = self.schema.copy()
@@ -51,6 +60,15 @@ class TestDTMetaSchema(unittest.TestCase):
                 schema_tmp['properties'] = self.schema['properties'].copy()
                 schema_tmp['properties'][key] = bad_props[key]
                 self.assertRaises(jsonschema.ValidationError, self.validator.validate, schema_tmp)
+
+class TestDTSchema(unittest.TestCase):
+    def test_binding_schemas_valid(self):
+        '''Test that all schema files under ./schemas/ validate against the DT metaschema'''
+        validator = dtschema.DTMetaValidator()
+        for filename in glob.iglob('schemas/**/*.yaml', recursive=True):
+            with self.subTest(schema=filename):
+                schema = dtschema.load_schema(filename)
+                validator.validate(schema)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test-dt-validate.py
+++ b/test/test-dt-validate.py
@@ -8,19 +8,14 @@ sys.path.insert(0, os.path.join(basedir, "../jsonschema-draft6"))
 import jsonschema
 sys.path.insert(0, os.path.join(basedir, ".."))
 import dtschema
+import pkgutil
 
 #validator = dtschema.DTValidator()
 
 class TestDTMetaSchema(unittest.TestCase):
     def setUp(self):
-        f = open("test/schemas/good-example.yaml")
-        self.schema = yaml.load(f.read())
-        f.close()
-
-        f = open("test/schemas/bad-example.yaml")
-        self.bad_schema = yaml.load(f.read())
-        f.close()
-
+        self.schema = yaml.load(pkgutil.get_data("dtschema", "test/schemas/good-example.yaml").decode("utf-8"))
+        self.bad_schema = yaml.load(pkgutil.get_data("dtschema", "test/schemas/bad-example.yaml").decode("utf-8"))
         self.validator = dtschema.DTMetaValidator()
 
     def test_required_properties(self):

--- a/tools/dt-doc-validate
+++ b/tools/dt-doc-validate
@@ -10,10 +10,8 @@ sys.path.insert(0, os.path.join(basedir, ".."))
 import dtschema
 import argparse
 import glob
-import pkgutil
 
 from jsonschema import FormatChecker
-from jsonschema.compat import urlopen
 
 def check_doc(filename):
     try:
@@ -31,7 +29,7 @@ def check_doc(filename):
 
     # Next, check against DT binding meta schema
     try:
-        schema = yaml.load(pkgutil.get_data("dtschema", "meta-schemas/core.yaml"))
+        schema = dtschema.load_schema('meta-schemas/core.yaml')
     except yaml.YAMLError as exc:
         print("Error in schema", filename, ": ", exc.path[-1], exc.message)
         return

--- a/tools/dt-doc-validate
+++ b/tools/dt-doc-validate
@@ -6,18 +6,13 @@ basedir = os.path.dirname(__file__)
 import yaml
 sys.path.insert(0, os.path.join(basedir, "../jsonschema-draft6"))
 import jsonschema
+sys.path.insert(0, os.path.join(basedir, ".."))
+import dtschema
 import argparse
 import glob
 
 from jsonschema import FormatChecker
 from jsonschema.compat import urlopen
-
-def yaml_handler(uri):
-    if "http://devicetree.org/" in uri:
-        yamlfile = open(uri.replace("http://devicetree.org", os.getcwd())).read()
-    else:
-        yamlfile = urlopen(uri).read().decode("utf-8")
-    return yaml.load(yamlfile)
 
 def check_doc(filename):
     try:
@@ -47,7 +42,7 @@ def check_doc(filename):
         print("Error(s) validating schema", exc)
         return
 
-    resolver = jsonschema.RefResolver.from_schema(schema, handlers={"http": yaml_handler})
+    resolver = jsonschema.RefResolver.from_schema(schema, handlers=dtschema.handlers)
     validator = jsonschema.Draft6Validator(schema, resolver=resolver, format_checker=FormatChecker())
     errors = sorted(validator.iter_errors(testtree), key=lambda e: e.path)
     for error in errors:

--- a/tools/dt-doc-validate
+++ b/tools/dt-doc-validate
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(basedir, ".."))
 import dtschema
 import argparse
 import glob
+import pkgutil
 
 from jsonschema import FormatChecker
 from jsonschema.compat import urlopen
@@ -30,7 +31,7 @@ def check_doc(filename):
 
     # Next, check against DT binding meta schema
     try:
-        schema = yaml.load(open("meta-schemas/core.yaml").read())
+        schema = yaml.load(pkgutil.get_data("dtschema", "meta-schemas/core.yaml"))
     except yaml.YAMLError as exc:
         print("Error in schema", filename, ": ", exc.path[-1], exc.message)
         return

--- a/tools/dt-doc-validate
+++ b/tools/dt-doc-validate
@@ -20,30 +20,13 @@ def check_doc(filename):
         print(filename + ":", exc.path[-1], exc.message)
         return
 
-    # first validate against JSON meta schema
+    # Make sure the document validates against the DT metaschema
     try:
-        jsonschema.Draft6Validator.check_schema(testtree)
+        dtschema.DTValidator.check_schema(testtree)
     except jsonschema.SchemaError as error:
         print("%s: in %s: %s" % (filename, list(error.path), error.message))
 
-
-    # Next, check against DT binding meta schema
-    try:
-        schema = dtschema.load_schema('meta-schemas/core.yaml')
-    except yaml.YAMLError as exc:
-        print("Error in schema", filename, ": ", exc.path[-1], exc.message)
-        return
-
-    # Check that the validation schema is valid
-    try:
-        jsonschema.Draft6Validator.check_schema(schema)
-    except jsonschema.SchemaError as exc:
-        print("Error(s) validating schema", exc)
-        return
-
-    resolver = jsonschema.RefResolver.from_schema(schema, handlers=dtschema.handlers)
-    validator = jsonschema.Draft6Validator(schema, resolver=resolver, format_checker=FormatChecker())
-    errors = sorted(validator.iter_errors(testtree), key=lambda e: e.path)
+    errors = sorted(dtschema.DTValidator.iter_schema_errors(testtree), key=lambda e: e.path)
     for error in errors:
         print("%s: in %s: %s" % (filename, list(error.path), error.message))
 

--- a/tools/dt-doc-validate
+++ b/tools/dt-doc-validate
@@ -2,7 +2,9 @@
 
 import os
 import sys
+basedir = os.path.dirname(__file__)
 import yaml
+sys.path.insert(0, os.path.join(basedir, "../jsonschema-draft6"))
 import jsonschema
 import argparse
 import glob


### PR DESCRIPTION
Hi Rob,

I’ve done some work to add formal test cases to the repo. Right now it is enough to check that all the required properties are in a schema file, and that bad properties will cause it to break. I’ve also added the jsonschema draft6 library as a sub module so that the right version can be picked up and we have a place to put fixups to that library. I’m mirroring it on the Devicetree github page. Finally, I updated the documentation.

I should really do some more testing on this before sending a pull req. It has only been tested on macOS, and not in a Linux yet. But I’m just home from 3 weeks on the road and need to take a break. I probably won’t touch it again before mid next week, so I wanted to push it out so you could take a look.