### PR TITLE
Switch to ruamel.yaml and improve error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 test:
 	test/test-dt-validate.py
 
-.PHONY: test
+demo-good-schema:
+	tools/dt-doc-validate test/schemas/good-example.yaml
+
+demo-bad-schema:
+	tools/dt-doc-validate test/schemas/bad-example.yaml
+
+.PHONY: test demo-bad-schema demo-good-schema

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Devicetree Meta-Schema files are normal YAML files using the jsonschema vocabula
 ## Usage
 The tool in this repo can be run by simply executing the dt-validate.py script
 at the top level. It requires Python 3 to be installed, as well as the
-jsonschema and pyyaml libraries.
+jsonschema and ruamel.yaml libraries.
 
 Please note: this is prototype code and is in no way officially supported or
 fit for use.
@@ -83,7 +83,13 @@ This code depends on Python 3 with the yaml and jsonschema libraries
 On Debian, the dependencies can be installed with:
 
 ```
-apt-get install python3 python-yaml
+apt-get install python3 python-ruamel.yaml
+```
+
+Alternately dependencies can be installed with pip:
+
+```
+pip3 install ruamel.yaml
 ```
 
 ### jsonschema Draft6

--- a/dt-validate.py
+++ b/dt-validate.py
@@ -3,12 +3,14 @@
 import sys
 import os
 basedir = os.path.dirname(__file__)
-import yaml
+import ruamel.yaml
 sys.path.insert(0, os.path.join(basedir, "jsonschema-draft6"))
 import jsonschema
 import argparse
 import glob
 import dtschema
+
+yaml = ruamel.yaml.YAML()
 
 def item_generator(json_input, lookup_key):
     if isinstance(json_input, dict):

--- a/dtschema.py
+++ b/dtschema.py
@@ -1,13 +1,15 @@
 # Python library for Devicetree schema validation
 import sys
 import os
-import yaml
+import ruamel.yaml
 sys.path.insert(0, os.path.join(os.path.dirname(__file__),
                                 "jsonschema-draft6"))
 import jsonschema
 import pkgutil
 
 schema_base_url = "http://devicetree.org/"
+
+yaml = ruamel.yaml.YAML()
 
 def load_schema(schema):
     return yaml.load(pkgutil.get_data('dtschema', schema).decode('utf-8'))

--- a/dtschema.py
+++ b/dtschema.py
@@ -50,8 +50,9 @@ class DTValidator(jsonschema.Draft6Validator):
     '''
     META_SCHEMA = load_schema('meta-schemas/core.yaml')
 
-    def __init__(self, schema, types=(), format_checker=None):
+    def __init__(self, schema, types=()):
         resolver = jsonschema.RefResolver.from_schema(schema, handlers=handlers)
+        format_checker = jsonschema.FormatChecker()
         jsonschema.Draft6Validator.__init__(self, schema, types, resolver=resolver,
                                             format_checker=format_checker)
 

--- a/test/schemas/bad-example.yaml
+++ b/test/schemas/bad-example.yaml
@@ -6,7 +6,10 @@ version: 2
 
 title: 0
 
-maintainers: Bob
+maintainers:
+  - Bob
+  - 12
+  - will.e@acme.co.uk
 
 description:
   - The description should not be a sequence.

--- a/test/test-dt-validate.py
+++ b/test/test-dt-validate.py
@@ -13,7 +13,6 @@ import os
 import glob
 import sys
 basedir = os.path.dirname(__file__)
-import yaml
 sys.path.insert(0, os.path.join(basedir, "../jsonschema-draft6"))
 import jsonschema
 sys.path.insert(0, os.path.join(basedir, ".."))

--- a/tools/dt-doc-validate
+++ b/tools/dt-doc-validate
@@ -3,15 +3,13 @@
 import os
 import sys
 basedir = os.path.dirname(__file__)
-import yaml
-sys.path.insert(0, os.path.join(basedir, "../jsonschema-draft6"))
-import jsonschema
+import ruamel.yaml
 sys.path.insert(0, os.path.join(basedir, ".."))
 import dtschema
 import argparse
 import glob
 
-from jsonschema import FormatChecker
+yaml = ruamel.yaml.YAML()
 
 def check_doc(filename):
     try:

--- a/tools/dt-doc-validate
+++ b/tools/dt-doc-validate
@@ -14,13 +14,12 @@ yaml = ruamel.yaml.YAML()
 def check_doc(filename):
     try:
         testtree = yaml.load(open(filename).read())
-    except yaml.YAMLError as exc:
+    except ruamel.yaml.YAMLError as exc:
         print(filename + ":", exc.path[-1], exc.message)
         return
 
-    errors = sorted(dtschema.DTValidator.iter_schema_errors(testtree), key=lambda e: e.path)
-    for error in errors:
-        print("%s: in %s: %s" % (filename, list(error.path), error.message))
+    for error in sorted(dtschema.DTValidator.iter_schema_errors(testtree), key=lambda e: e.linecol):
+        print(dtschema.format_error(filename, error, verbose=False))
 
 
 if __name__ == "__main__":

--- a/tools/dt-doc-validate
+++ b/tools/dt-doc-validate
@@ -20,19 +20,12 @@ def check_doc(filename):
         print(filename + ":", exc.path[-1], exc.message)
         return
 
-    # Make sure the document validates against the DT metaschema
-    try:
-        dtschema.DTValidator.check_schema(testtree)
-    except jsonschema.SchemaError as error:
-        print("%s: in %s: %s" % (filename, list(error.path), error.message))
-
     errors = sorted(dtschema.DTValidator.iter_schema_errors(testtree), key=lambda e: e.path)
     for error in errors:
         print("%s: in %s: %s" % (filename, list(error.path), error.message))
 
 
 if __name__ == "__main__":
-
     ap = argparse.ArgumentParser()
     ap.add_argument("yamldt", type=str,
                     help="Filename of YAML encoded devicetree input file")

--- a/tools/extract-compatibles
+++ b/tools/extract-compatibles
@@ -2,8 +2,10 @@
 
 import os
 import sys
-import yaml
+import ruamel.yaml
 import argparse
+
+yaml = ruamel.yaml.YAML()
 
 def item_generator(json_input, lookup_key):
     if isinstance(json_input, dict):

--- a/tools/yaml2json
+++ b/tools/yaml2json
@@ -2,8 +2,10 @@
 
 import sys
 import argparse
-import yaml
+import ruamel.yaml
 import json
+
+yaml = ruamel.yaml.YAML()
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()


### PR DESCRIPTION
This series switches the entire repo to use ruamel.yaml instead of pyyaml. ruamel.yaml has some nice features for preserving the input data, and can be used to retrieve the original source line numbers from a YAML file. The line number feature is used to make the error messages from dt-doc-validate more useful.