### PR TITLE
schemas: chosen: Add nodes and properties for simple-framebuffer

### DIFF
--- a/schemas/chosen.yaml
+++ b/schemas/chosen.yaml
@@ -24,6 +24,10 @@ description:
 properties:
   $nodename:
     const: chosen
+
+  "#address-cells": true
+  "#size-cells": true
+
   bootargs:
     $ref: types.yaml#definitions/string
 
@@ -147,5 +151,8 @@ properties:
       or on PowerPC "stdout" if "stdout-path" is not found.  However, the
       "linux,stdout-path" and "stdout" properties are deprecated. New platforms
       should only use the "stdout-path" property.
+
+patternProperties:
+  "^framebuffer": true
 
 additionalProperties: false


### PR DESCRIPTION
The simple-framebuffer binding allows to have child nodes to /chosen, whith
a reg property, so #address-cells and #size-cells will be there.

List those properties in the chosen schemas to remove the warnings when
those properties are there.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>