### PR TITLE
dtschema: Add pinctrl properties by default

### DIFF
--- a/dtschema/lib.py
+++ b/dtschema/lib.py
@@ -359,6 +359,22 @@ def fixup_node_props(schema):
     schema['properties']['phandle'] = True
     schema['properties']['status'] = True
 
+    keys = list()
+    if 'properties' in schema:
+        keys.extend(schema['properties'])
+
+    if 'patternProperties' in schema:
+        keys.extend(schema['patternProperties'])
+
+    for key in keys:
+        if "pinctrl" in key:
+            break
+
+    else:
+        schema['properties']['pinctrl-names'] = True
+        schema.setdefault('patternProperties', dict())
+        schema['patternProperties']['pinctrl-[0-9]+'] = True
+
 def process_schema(filename):
     try:
         schema = load_schema(filename)


### PR DESCRIPTION
Since pinctrl properties are handled by the core itself most of the time,
and are not always essential to the operations of a driver (for example if
the bootloader is in charge of the muxing), we would have to add the
pinctrl-names and pinctrl-[0-299] properties to pretty much every YAML
schema.

Add them in the tools instead just like status.

Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>