### PR TITLE
Update dt-extract-example

### DIFF
--- a/tools/dt-extract-example
+++ b/tools/dt-extract-example
@@ -15,8 +15,7 @@ example_template = """
         #address-cells = <1>;
         #size-cells = <1>;
 
-{example}
-
+        {example}
     }};
 }};
 """

--- a/tools/dt-extract-example
+++ b/tools/dt-extract-example
@@ -4,6 +4,7 @@
 # Copyright 2019 Arm Ltd.
 
 import os
+import re
 import sys
 import ruamel.yaml
 import argparse
@@ -17,11 +18,14 @@ example_template = """
 {example}
 
     }};
+}};
 """
 
 example_header = """
 /dts-v1/;
 /plugin/; // silence any missing phandle references
+"""
+example_start = """
 /{
     compatible = "foo";
     model = "foo";
@@ -49,7 +53,15 @@ if __name__ == "__main__":
 
     if 'examples' in binding.keys():
         for idx,ex in enumerate(binding['examples']):
-            ex = '        '.join(ex.splitlines(True))
-            print(example_template.format(example=ex,example_num=idx))
+            # Check if example contains a root node "/{"
+            root_node = re.search('^/\s*{', ex)
 
-    print("\n};")
+            if not root_node:
+                print(example_start)
+                ex = '        '.join(ex.splitlines(True))
+                print(example_template.format(example=ex,example_num=idx))
+            else:
+                print(ex)
+    else:
+        print(example_start)
+        print("\n};")


### PR DESCRIPTION
The patches were sent to the device-tree list: https://lore.kernel.org/linux-devicetree/20200425105255.1064-1-sam@ravnborg.org/
But I assumed it would be more convenient to handle a pull request.
So here goes.

The first one patch to add support for root nodes in dt-extract-example.
This will allow us to modify the example for simple-framebuffer to it
is more correct without any warnings.
And we may have the potential to use this in other places.

Verified that this did not introduce any regressions in
mainline kernel.

Looking at the generating output there was one line with the wrong ident.
Fixed this so reading the generated output was a little easier
to the eye. The fix has no impact on the checks.

Patching simple-frambuffer.yaml in the kernel will
have to wait a little. At a minimum, this patch should be accepted
and dt-schema shall have a higher version.

