### PR TITLE
PCI and GPIO updates, typofixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Found in `./meta-schemas`
 
 *Devicetree Meta-Schemas* describe the data format of Devicetree Schema files.
 The Meta-schemas make sure all the binding schemas are in the correct format
-and the tool will emit an error is the format is incorrect.
+and the tool will emit an error if the format is incorrect.
 
 As a developer you normally will not need to write metaschema files.
 
@@ -89,9 +89,9 @@ them against the DT meta-schema.
 
 tools/dt-mk-schema
 This tool takes user provided schema file(s) plus the core schema files in this
-repo, removed everything not needed for validation, applies fix-ups to the
-schemas, and outputs a single file with the processed schema. This is step is
-done separately to speed up subsequent validate of YAML Devicetrees.
+repo, removes everything not needed for validation, applies fix-ups to the
+schemas, and outputs a single file with the processed schema. This step is
+done separately to speed up subsequent validation of YAML Devicetrees.
 
 tools/dt-validate
 This tool takes user provided YAML Devicetree(s) and either a schema directory

--- a/dtschema/lib.py
+++ b/dtschema/lib.py
@@ -619,28 +619,30 @@ def http_handler(uri):
 
 handlers = {"http": http_handler}
 
-def typeSize(validator, typeSize, instance, schema):
-    if (isinstance(instance[0], tagged_list)):
-        if typeSize != instance[0].type_size:
-            yield jsonschema.ValidationError("size is %r, expected %r" % (instance[0].type_size, typeSize))
-    elif isinstance(instance[0], list) and isinstance(instance[0][0], int) and \
-        typeSize == 32:
-        # 32-bit sizes aren't explicitly tagged
-        return
-    else:
-        yield jsonschema.ValidationError("missing size tag in %r" % instance)
+class typeSize(jsonschema.Validator):
+    def validate(self, validator, typeSize, instance, schema):
+        if (isinstance(instance[0], tagged_list)):
+            if typeSize != instance[0].type_size:
+                yield jsonschema.ValidationError("size is %r, expected %r" % (instance[0].type_size, typeSize))
+        elif isinstance(instance[0], list) and isinstance(instance[0][0], int) and \
+            typeSize == 32:
+            # 32-bit sizes aren't explicitly tagged
+            return
+        else:
+            yield jsonschema.ValidationError("missing size tag in %r" % instance)
 
-def phandle(validator, phandle, instance, schema):
-    if not isinstance(instance, phandle_int):
-        yield jsonschema.ValidationError("missing phandle tag in %r" % instance)
+class phandle(jsonschema.Validator):
+    def validate(self, validator, phandle, instance, schema):
+        if not isinstance(instance, phandle_int):
+            yield jsonschema.ValidationError("missing phandle tag in %r" % instance)
 
-DTVal = jsonschema.validators.extend(jsonschema.Draft7Validator, {'typeSize': typeSize, 'phandle': phandle})
+DTVal = jsonschema.validators.extend(jsonschema.Draft8Validator, {'typeSize': typeSize, 'phandle': phandle})
 
 class DTValidator(DTVal):
     '''Custom Validator for Devicetree Schemas
 
-    Overrides the Draft7 metaschema with the devicetree metaschema. This
-    validator is used in exactly the same way as the Draft7Validator. Schema
+    Overrides the Draft8 metaschema with the devicetree metaschema. This
+    validator is used in exactly the same way as the Draft8Validator. Schema
     files can be validated with the .check_schema() method, and .validate()
     will check the data in a devicetree file.
     '''
@@ -648,7 +650,7 @@ class DTValidator(DTVal):
     format_checker = jsonschema.FormatChecker()
 
     def __init__(self, schema, types=()):
-        jsonschema.Draft7Validator.__init__(self, schema, types, resolver=self.resolver,
+        jsonschema.Draft8Validator.__init__(self, schema, types, resolver=self.resolver,
                                             format_checker=self.format_checker)
 
     @classmethod
@@ -659,7 +661,7 @@ class DTValidator(DTVal):
             yield error
 
     def iter_errors(self, instance, _schema=None):
-        for error in jsonschema.Draft7Validator.iter_errors(self, instance, _schema):
+        for error in jsonschema.Draft8Validator.iter_errors(self, instance, _schema):
             error.linecol = get_line_col(instance, error.path)
             yield error
 

--- a/meta-schemas/items.yaml
+++ b/meta-schemas/items.yaml
@@ -27,8 +27,11 @@ allOf:
   - if:
       required:
         - items
-        - minItems
-        - maxItems
+      anyOf:
+        - required:
+            - minItems
+        - required:
+            - maxItems
       oneOf:
         - properties:
             items:

--- a/meta-schemas/keywords.yaml
+++ b/meta-schemas/keywords.yaml
@@ -79,7 +79,11 @@ properties:
   additionalItems:
     type: boolean
   additionalProperties:
-    type: boolean
+    oneOf:
+      - type: object
+        allOf:
+          - $ref: "#/definitions/sub-schemas"
+      - type: boolean
   allOf:
     items:
       $ref: "#/definitions/sub-schemas"
@@ -140,7 +144,11 @@ properties:
   type: true
   typeSize: true
   unevaluatedProperties:
-    type: boolean
+    oneOf:
+      - type: object
+        allOf:
+          - $ref: "#/definitions/sub-schemas"
+      - type: boolean
   uniqueItems:
     type: boolean
 

--- a/schemas/gpio/gpio-consumer.yaml
+++ b/schemas/gpio/gpio-consumer.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2018 Linaro Ltd.
+$id: "http://devicetree.org/schemas/gpio/gpio-consumer.yaml#"
+$schema: "http://devicetree.org/meta-schemas/base.yaml#"
+title: GPIO consumer devicetree schema
+description: "Schema for GPIO consumer devicetree bindings"
+maintainers:
+  - Rob Herring <robh@kernel.org>
+
+# do not select this schema for GPIO hogs
+select:
+  properties:
+    gpio-hog: false
+
+properties:
+  gpios:
+    $ref: "/schemas/types.yaml#/definitions/phandle-array"
+
+patternProperties:
+  "(?<!,nr)-gpios?$":
+    $ref: "/schemas/types.yaml#/definitions/phandle-array"

--- a/schemas/gpio/gpio-hog.yaml
+++ b/schemas/gpio/gpio-hog.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2018 Linaro Ltd.
+$id: "http://devicetree.org/schemas/gpio/gpio-hog.yaml#"
+$schema: "http://devicetree.org/meta-schemas/base.yaml#"
+title: GPIO hog devicetree schema
+description: "Schema for GPIO hog devicetree bindings"
+maintainers:
+  - Rob Herring <robh@kernel.org>
+
+# select this schema for GPIO hogs
+select:
+  properties:
+    gpio-hog: true
+
+  required:
+    - gpio-hog
+
+properties:
+  gpio-hog:
+    $ref: "/schemas/types.yaml#/definitions/flag"
+
+  gpios:
+    $ref: "/schemas/types.yaml#/definitions/uint32-matrix"
+
+  input:
+    $ref: "/schemas/types.yaml#/definitions/flag"
+
+  line-name:
+    $ref: "/schemas/types.yaml#/definitions/string"
+
+  output-high:
+    $ref: "/schemas/types.yaml#/definitions/flag"
+
+  output-low:
+    $ref: "/schemas/types.yaml#/definitions/flag"
+
+required:
+  - gpio-hog
+  - gpios

--- a/schemas/gpio/gpio.yaml
+++ b/schemas/gpio/gpio.yaml
@@ -33,12 +33,6 @@ properties:
       - type: object
       - $ref: "/schemas/types.yaml#/definitions/phandle-array"
 
-patternProperties:
-  "(?<!,nr)-gpios?$":
-    $ref: "/schemas/types.yaml#/definitions/phandle-array"
-  "^gpios$":
-    $ref: "/schemas/types.yaml#/definitions/phandle-array"
-
 dependencies:
   gpio-controller: ['#gpio-cells']
   '#gpio-cells': [ gpio-controller ]

--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -28,19 +28,21 @@ properties:
     pattern: "^pcie?@"
 
   ranges:
-    minItems: 1
-    maxItems: 32    # Should be enough
-    items:
-      minItems: 5
-      maxItems: 7
-      additionalItems: true
-      items:
-        - enum:
-            - 0x01000000
-            - 0x02000000
-            - 0x03000000
-            - 0x42000000
-            - 0x43000000
+    oneOf:
+      - $ref: "/schemas/types.yaml#/definitions/flag"
+      - minItems: 1
+        maxItems: 32    # Should be enough
+        items:
+          minItems: 5
+          maxItems: 7
+          additionalItems: true
+          items:
+            - enum:
+                - 0x01000000
+                - 0x02000000
+                - 0x03000000
+                - 0x42000000
+                - 0x43000000
 
   dma-ranges:
     oneOf:

--- a/schemas/reg.yaml
+++ b/schemas/reg.yaml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2020 Arm Ltd.
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/reg.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: reg property checks
+
+description: |
+  Common checks for 'reg' properties
+
+maintainers:
+  - Rob Herring <robh@kernel.org>
+
+select: true
+
+properties: {}
+
+allOf:
+  - if:
+      properties:
+        '#address-cells':
+          const: 2
+        '#size-cells':
+          const: 2
+      required:
+        - '#address-cells'
+        - '#size-cells'
+    then:
+      patternProperties:
+        '@':
+          properties:
+            reg:
+              items:
+                minItems: 4
+                maxItems: 4
+
+  - if:
+      properties:
+        '#address-cells':
+          const: 1
+        '#size-cells':
+          const: 1
+      required:
+        - '#address-cells'
+        - '#size-cells'
+    then:
+      patternProperties:
+        '@':
+          properties:
+            reg:
+              items:
+                minItems: 2
+                maxItems: 2
+
+  - if:
+      properties:
+        '#address-cells':
+          const: 2
+        '#size-cells':
+          const: 1
+      required:
+        - '#address-cells'
+        - '#size-cells'
+    then:
+      patternProperties:
+        '@':
+          properties:
+            reg:
+              items:
+                minItems: 3
+                maxItems: 3
+
+...

--- a/test/schemas/good-example.yaml
+++ b/test/schemas/good-example.yaml
@@ -128,8 +128,7 @@ properties:
   vendor,string-list-prop:
     allOf:
      - $ref: "/schemas/types.yaml#/definitions/string-array"
-     - minItems: 2
-       items:
+     - items:
          - const: foobar
          - const: foobaz
     description: Vendor specific string list property

--- a/tools/dt-validate
+++ b/tools/dt-validate
@@ -101,7 +101,7 @@ class schema_group():
         """Check the given DT against all schemas"""
 
         for schema in self.schemas:
-            schema["$select_validator"] = jsonschema.Draft7Validator(schema['select'])
+            schema["$select_validator"] = jsonschema.Draft8Validator(schema['select'])
 
         for subtree in dt:
             self.check_subtree(dt, subtree, "/", "/", filename)


### PR DESCRIPTION
These changes contain a few typofixes for the README. A new schema is added for GPIO hogs in a way that they don't conflict with the GPIO consumer bindings. Finally the PCI bus schema is modified to support an empty 'ranges' property, which is useful for PCI root ports which don't need any extra translation on top of the PCI host bridge translation.