### PR TITLE
PCI and GPIO updates, typofixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Found in `./meta-schemas`
 
 *Devicetree Meta-Schemas* describe the data format of Devicetree Schema files.
 The Meta-schemas make sure all the binding schemas are in the correct format
-and the tool will emit an error is the format is incorrect.
+and the tool will emit an error if the format is incorrect.
 
 As a developer you normally will not need to write metaschema files.
 
@@ -89,9 +89,9 @@ them against the DT meta-schema.
 
 tools/dt-mk-schema
 This tool takes user provided schema file(s) plus the core schema files in this
-repo, removed everything not needed for validation, applies fix-ups to the
-schemas, and outputs a single file with the processed schema. This is step is
-done separately to speed up subsequent validate of YAML Devicetrees.
+repo, removes everything not needed for validation, applies fix-ups to the
+schemas, and outputs a single file with the processed schema. This step is
+done separately to speed up subsequent validation of YAML Devicetrees.
 
 tools/dt-validate
 This tool takes user provided YAML Devicetree(s) and either a schema directory

--- a/schemas/gpio/gpio-consumer.yaml
+++ b/schemas/gpio/gpio-consumer.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2018 Linaro Ltd.
+$id: "http://devicetree.org/schemas/gpio/gpio-consumer.yaml#"
+$schema: "http://devicetree.org/meta-schemas/base.yaml#"
+title: GPIO consumer devicetree schema
+description: "Schema for GPIO consumer devicetree bindings"
+maintainers:
+  - Rob Herring <robh@kernel.org>
+
+# do not select this schema for GPIO hogs
+select:
+  properties:
+    gpio-hog: false
+
+properties:
+  gpios:
+    $ref: "/schemas/types.yaml#/definitions/phandle-array"
+
+patternProperties:
+  "(?<!,nr)-gpios?$":
+    $ref: "/schemas/types.yaml#/definitions/phandle-array"

--- a/schemas/gpio/gpio-hog.yaml
+++ b/schemas/gpio/gpio-hog.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright 2018 Linaro Ltd.
+$id: "http://devicetree.org/schemas/gpio/gpio-hog.yaml#"
+$schema: "http://devicetree.org/meta-schemas/base.yaml#"
+title: GPIO hog devicetree schema
+description: "Schema for GPIO hog devicetree bindings"
+maintainers:
+  - Rob Herring <robh@kernel.org>
+
+# select this schema for GPIO hogs
+select:
+  properties:
+    gpio-hog: true
+
+  required:
+    - gpio-hog
+
+properties:
+  gpio-hog:
+    $ref: "/schemas/types.yaml#/definitions/flag"
+
+  gpios:
+    $ref: "/schemas/types.yaml#/definitions/uint32-matrix"
+
+  input:
+    $ref: "/schemas/types.yaml#/definitions/flag"
+
+  line-name:
+    $ref: "/schemas/types.yaml#/definitions/string"
+
+  output-high:
+    $ref: "/schemas/types.yaml#/definitions/flag"
+
+  output-low:
+    $ref: "/schemas/types.yaml#/definitions/flag"
+
+required:
+  - gpio-hog
+  - gpios

--- a/schemas/gpio/gpio.yaml
+++ b/schemas/gpio/gpio.yaml
@@ -33,12 +33,6 @@ properties:
       - type: object
       - $ref: "/schemas/types.yaml#/definitions/phandle-array"
 
-patternProperties:
-  "(?<!,nr)-gpios?$":
-    $ref: "/schemas/types.yaml#/definitions/phandle-array"
-  "^gpios$":
-    $ref: "/schemas/types.yaml#/definitions/phandle-array"
-
 dependencies:
   gpio-controller: ['#gpio-cells']
   '#gpio-cells': [ gpio-controller ]

--- a/schemas/pci/pci-bus.yaml
+++ b/schemas/pci/pci-bus.yaml
@@ -28,19 +28,21 @@ properties:
     pattern: "^pcie?@"
 
   ranges:
-    minItems: 1
-    maxItems: 32    # Should be enough
-    items:
-      minItems: 5
-      maxItems: 7
-      additionalItems: true
-      items:
-        - enum:
-            - 0x01000000
-            - 0x02000000
-            - 0x03000000
-            - 0x42000000
-            - 0x43000000
+    oneOf:
+      - $ref: "/schemas/types.yaml#/definitions/flag"
+      - minItems: 1
+        maxItems: 32    # Should be enough
+        items:
+          minItems: 5
+          maxItems: 7
+          additionalItems: true
+          items:
+            - enum:
+                - 0x01000000
+                - 0x02000000
+                - 0x03000000
+                - 0x42000000
+                - 0x43000000
 
   dma-ranges:
     oneOf:


### PR DESCRIPTION
These changes contain a few typofixes for the README. A new schema is added for GPIO hogs in a way that they don't conflict with the GPIO consumer bindings. Finally the PCI bus schema is modified to support an empty 'ranges' property, which is useful for PCI root ports which don't need any extra translation on top of the PCI host bridge translation.