### PR TITLE
dt-validate: Check status of correct instance

### DIFF
--- a/tools/dt-validate
+++ b/tools/dt-validate
@@ -58,8 +58,8 @@ class schema_group():
                         # boards using that particular node. Thus, if the
                         # node is marked as disabled, let's just ignore
                         # any error message reporting a missing property.
-                        if 'status' in node and \
-                           'disabled' in node['status'] and \
+                        if 'status' in error.instance and \
+                           'disabled' in error.instance['status'] and \
                            'required property' in error.message:
                             continue
 


### PR DESCRIPTION
When deciding whether or not to emit an error, look at the 'status'
property of the instance that failed to validate rather than of the
node that is being checked.

Cases where this can happen are when a schema describes required
properties for patternProperties or other child nodes, in which case
the invalid instance differs from the node being checked.

Signed-off-by: Thierry Reding <treding@nvidia.com>